### PR TITLE
iptables-nft is our default packet filtering tool

### DIFF
--- a/iptables.spec
+++ b/iptables.spec
@@ -488,7 +488,7 @@ fi
 pfx=%{_sbindir}/iptables
 pfx6=%{_sbindir}/ip6tables
 %{_sbindir}/update-alternatives --install \
-    $pfx iptables $pfx-nft 5 \
+    $pfx iptables $pfx-nft 10 \
 	--slave $pfx6 ip6tables $pfx6-nft \
 	--slave $pfx-restore iptables-restore $pfx-nft-restore \
 	--slave $pfx-save iptables-save $pfx-nft-save \
@@ -506,7 +506,7 @@ if [ "$(readlink -e $manpfx.8%{_extension})" == $manpfx.8%{_extension} ]; then
     rm -f $manpfx.8%{_extension}
 fi
 %{_sbindir}/update-alternatives --install \
-    $pfx ebtables $pfx-nft 5 \
+    $pfx ebtables $pfx-nft 10 \
 	--slave $pfx-save ebtables-save $pfx-nft-save \
 	--slave $pfx-restore ebtables-restore $pfx-nft-restore \
 	--slave $manpfx.8%{_extension} ebtables-man $manpfx-nft.8%{_extension}
@@ -526,7 +526,7 @@ if [ "$(readlink -e $lepfx-helper)" == $lepfx-helper ]; then
     rm -f $lepfx-helper
 fi
 %{_sbindir}/update-alternatives --install \
-    $pfx arptables $pfx-nft 5 \
+    $pfx arptables $pfx-nft 10 \
 	--slave $pfx-save arptables-save $pfx-nft-save \
 	--slave $pfx-restore arptables-restore $pfx-nft-restore \
 	--slave $manpfx.8%{_extension} arptables-man $manpfx-nft.8%{_extension} \

--- a/iptables.spec
+++ b/iptables.spec
@@ -45,7 +45,7 @@ Name:		iptables
 Summary:	Tools for managing Linux kernel packet filtering capabilities
 URL:		http://www.netfilter.org/projects/iptables
 Version:	1.8.6
-Release:	3
+Release:	4
 # pf.os: ISC license
 # iptables-apply: Artistic Licence 2.0
 License:	GPLv2 and Artistic Licence 2.0 and ISC
@@ -247,6 +247,9 @@ Summary:	nftables compatibility for iptables, arptables and ebtables
 Requires:	%{name} = %{version}-%{release}
 Obsoletes:	iptables-compat < 1.6.2-4
 Provides:	arptables-helper
+Provides:	arptables
+Provides:	ebtables
+Provides:	iptables
 
 %description nft
 nftables compatibility for iptables, arptables and ebtables.
@@ -485,7 +488,7 @@ fi
 pfx=%{_sbindir}/iptables
 pfx6=%{_sbindir}/ip6tables
 %{_sbindir}/update-alternatives --install \
-	$pfx iptables $pfx-nft 5 \
+    $pfx iptables $pfx-nft 5 \
 	--slave $pfx6 ip6tables $pfx6-nft \
 	--slave $pfx-restore iptables-restore $pfx-nft-restore \
 	--slave $pfx-save iptables-save $pfx-nft-save \
@@ -495,15 +498,15 @@ pfx6=%{_sbindir}/ip6tables
 pfx=%{_sbindir}/ebtables
 manpfx=%{_mandir}/man8/ebtables
 for sfx in "" "-restore" "-save"; do
-	if [ "$(readlink -e $pfx$sfx)" == $pfx$sfx ]; then
-		rm -f $pfx$sfx
-	fi
+    if [ "$(readlink -e $pfx$sfx)" == $pfx$sfx ]; then
+	rm -f $pfx$sfx
+    fi
 done
 if [ "$(readlink -e $manpfx.8%{_extension})" == $manpfx.8%{_extension} ]; then
-	rm -f $manpfx.8%{_extension}
+    rm -f $manpfx.8%{_extension}
 fi
 %{_sbindir}/update-alternatives --install \
-	$pfx ebtables $pfx-nft 5 \
+    $pfx ebtables $pfx-nft 5 \
 	--slave $pfx-save ebtables-save $pfx-nft-save \
 	--slave $pfx-restore ebtables-restore $pfx-nft-restore \
 	--slave $manpfx.8%{_extension} ebtables-man $manpfx-nft.8%{_extension}
@@ -512,18 +515,18 @@ pfx=%{_sbindir}/arptables
 manpfx=%{_mandir}/man8/arptables
 lepfx=%{_libexecdir}/arptables
 for sfx in "" "-restore" "-save"; do
-	if [ "$(readlink -e $pfx$sfx)" == $pfx$sfx ]; then
-		rm -f $pfx$sfx
-	fi
-	if [ "$(readlink -e $manpfx$sfx.8%{_extension})" == $manpfx$sfx.8%{_extension} ]; then
-		rm -f $manpfx$sfx.8%{_extension}
-	fi
+    if [ "$(readlink -e $pfx$sfx)" == $pfx$sfx ]; then
+	rm -f $pfx$sfx
+    fi
+    if [ "$(readlink -e $manpfx$sfx.8%{_extension})" == $manpfx$sfx.8%{_extension} ]; then
+	rm -f $manpfx$sfx.8%{_extension}
+    fi
 done
 if [ "$(readlink -e $lepfx-helper)" == $lepfx-helper ]; then
-	rm -f $lepfx-helper
+    rm -f $lepfx-helper
 fi
 %{_sbindir}/update-alternatives --install \
-	$pfx arptables $pfx-nft 5 \
+    $pfx arptables $pfx-nft 5 \
 	--slave $pfx-save arptables-save $pfx-nft-save \
 	--slave $pfx-restore arptables-restore $pfx-nft-restore \
 	--slave $manpfx.8%{_extension} arptables-man $manpfx-nft.8%{_extension} \
@@ -533,10 +536,10 @@ fi
 
 %postun nft
 if [ $1 -eq 0 ]; then
-	for cmd in iptables ebtables arptables; do
-		%{_sbindir}/update-alternatives --remove \
-			$cmd %{_sbindir}/$cmd-nft
-	done
+    for cmd in iptables ebtables arptables; do
+	%{_sbindir}/update-alternatives --remove \
+	$cmd %{_sbindir}/$cmd-nft
+    done
 fi
 
 %files


### PR DESCRIPTION
iptables is very legacy, time to use iptables-nft as our default packet filtering tool.
Drop in replacement is provided by iptables-nft